### PR TITLE
Shadow joining on long edges

### DIFF
--- a/src/MinistryOfCoolWalks.jl
+++ b/src/MinistryOfCoolWalks.jl
@@ -82,7 +82,7 @@ const HIGHWAYS_NOT_OFFSET = [
 
 export sunposition  # imported from CoolWalksUtils
 
-export add_shadow_intervals!, check_shadow_angle_integrity
+export add_shadow_intervals!, check_shadow_angle_integrity, npoints
 include("ShadowIntersection.jl")
 
 export build_rtree

--- a/src/MinistryOfCoolWalks.jl
+++ b/src/MinistryOfCoolWalks.jl
@@ -82,7 +82,7 @@ const HIGHWAYS_NOT_OFFSET = [
 
 export sunposition  # imported from CoolWalksUtils
 
-export add_shadow_intervals!
+export add_shadow_intervals!, check_shadow_angle_integrity
 include("ShadowIntersection.jl")
 
 export build_rtree

--- a/src/ShadowIntersection.jl
+++ b/src/ShadowIntersection.jl
@@ -340,9 +340,11 @@ function check_shadow_angle_integrity(g, max_angle)
     df = DataFrame((edge=e, shadowgeom=get_prop(g, e, :shadowgeom)) for e in filter_edges(g, :shadowgeom))
     df.angles = angles_in.(df.shadowgeom)
     df.all_less = all_less_than.(df.angles, max_angle)
+    df.max_angle = map(a -> length(a) == 0 ? 0.0 : maximum(a), df.angles)
     no_problem = all(df.all_less)
+    max_enc_angle = maximum(df.max_angle)
     if no_problem
-        @info "all angles between segments in the :shadowgeom field are less than $(max_angle)!"
+        @info "all angles between segments in the :shadowgeom field are less than $(max_angle)! (largest encountered angle: $max_enc_angle)"
     else
         filter!(:all_less => !, df)
         @warn "$(nrow(df)) edges have angles larger than $max_angle. Returning problematic values."

--- a/src/ShadowIntersection.jl
+++ b/src/ShadowIntersection.jl
@@ -250,7 +250,7 @@ function add_shadow_intervals!(g, shadows; clear_old_shadows=false)
     shadow_tree = build_rtree(shadows.geometry)
 
     #return shadow_tree
-    @showprogress 1 "adding shadows" for edge in edges(g)#[Edge(7228, 1911)]#edges(g)
+    @showprogress 1 "adding shadows" for edge in edges(g)
         !has_prop(g, edge, :edgegeom) && continue  # skip helpers
 
         # add or reset all numeric props on edges which not yet have them
@@ -348,8 +348,8 @@ function check_shadow_angle_integrity(g, max_angle)
     else
         filter!(:all_less => !, df)
         @warn "$(nrow(df)) edges have angles larger than $max_angle. Returning problematic values."
-        return df
     end
+    return df
 end
 
 

--- a/src/ShadowIntersection.jl
+++ b/src/ShadowIntersection.jl
@@ -384,3 +384,16 @@ end
 checks if all values in `angles` are less than `max_angle`.
 """
 all_less_than(angles, max_angle) = mapreduce(<(max_angle), &, angles, init=true)
+
+"""
+
+    npoints(line)
+    npoints(::LineStringTrait, line)
+    npoints(::MultiLineStringTrait, line)
+
+calculates the number of points in a line or multiline.
+"""
+npoints(line) = npoints(geomtrait(line), line)
+
+npoints(::LineStringTrait, line) = ngeom(line)
+npoints(::MultiLineStringTrait, line) = mapreduce(ngeom, +, getgeom(line))

--- a/test/ShadowIntersection.jl
+++ b/test/ShadowIntersection.jl
@@ -71,4 +71,16 @@
             @test sl_after ≈ sl || sl_after <= sl  # might be slightly larger, due to numerics.
         end
     end
+
+    @testset "check_shadow_angle_integrity" begin
+        g = shadow_graph_from_file("./data/test_clifton_bike.json"; network_type=:bike)
+        b = load_british_shapefiles("./data/clifton/clifton_test.shp")
+        s = CompositeBuildings.cast_shadow(b, :height_mean, [1.0, -0.4, 0.2])
+        add_shadow_intervals!(g, s)
+
+        @test check_shadow_angle_integrity(g, 0.9π) isa Nothing
+
+        problems = check_shadow_angle_integrity(g, 0.1π)
+        @test nrow(problems) == 296
+    end
 end

--- a/test/ShadowIntersection.jl
+++ b/test/ShadowIntersection.jl
@@ -78,9 +78,10 @@
         s = CompositeBuildings.cast_shadow(b, :height_mean, [1.0, -0.4, 0.2])
         add_shadow_intervals!(g, s)
 
-        @test check_shadow_angle_integrity(g, 0.9π) isa Nothing
+        no_problems = check_shadow_angle_integrity(g, 0.9π)
+        @test nrow(no_problems) == 1506
 
         problems = check_shadow_angle_integrity(g, 0.1π)
-        @test nrow(problems) == 296
+        @test nrow(problems) == 228
     end
 end


### PR DESCRIPTION
- added a function to validate the shadow interval addition
- added function to get number of points of line (maybe move it to the utils package?)
- added functions for calculating angles of linesegments (maybe move to the utils package?)
- added tests for validation function
- the shadows from the shadow intersection call are no longer thrown into a `ArchGDAL.union`, since this creates a lot of short edges, leading to high numbers of points in the combined edge, as well as strange bugs when the edge is shorter than the buffer size. We rather just add all shadow intersection linestrings to a multilinestring, without unionizing, and go from there.